### PR TITLE
ensure indexFilePath directory exists

### DIFF
--- a/src/merge-reports.ts
+++ b/src/merge-reports.ts
@@ -171,6 +171,7 @@ async function mergeHTMLReports(inputReportPaths: string[], givenConfig: Config 
   }
 
   const indexFilePath = path.join(outputPath, "index.html");
+  await mkdir(path.dirname(indexFilePath), { recursive: true });
   await writeFile(indexFilePath, baseIndexHtml + `<script>
 window.playwrightReportBase64 = "data:application/zip;base64,`)
 


### PR DESCRIPTION
Hi! This library is really great - but I haven't been able to get it to work without patching the code in `node_modules`. So thought I'd open this PR here instead.

I'm hitting

```
Error: ENOENT: no such file or directory, open '/path/to/my/repo/dist/playwright/merged-html/index.html'
```

If I try to create it manually it gets deleted with `overwriteExisting` on, and with it off, the job gets abandoned because the folder already exists. Am I doing something wrong? If so, I'll close the PR!